### PR TITLE
change dispatchBrowserEvent to dispatch

### DIFF
--- a/src/Http/Livewire/LivewireToast.php
+++ b/src/Http/Livewire/LivewireToast.php
@@ -81,7 +81,7 @@ class LivewireToast extends Component
         $this->_setTransition();
         
         if (!empty($this->message)) {
-            $this->dispatchBrowserEvent('new-toast');
+            $this->dispatch('new-toast');
         }
         return view('livewire-toast::livewire.livewire-toast');
     }


### PR DESCRIPTION
change dispatchBrowserEvent to dispatch to accommodate livewire v3 which uses dispatch instead of dispatchBrowserEvent